### PR TITLE
Adding method validations option

### DIFF
--- a/src/EloquentInteractions/Interaction.php
+++ b/src/EloquentInteractions/Interaction.php
@@ -48,9 +48,10 @@ abstract class Interaction {
    * @param array $params Interaction parameters
    */
   public function __construct($params = []) {
-    $this->validator = Validator::make($params, $this->validations, ['object' => 'The :attribute object type is invalid.']);
-
     $this->params = $params;
+
+    $validations = method_exists($this, 'validations') ? $this->validations() : $this->validations;
+    $this->validator = Validator::make($params, $validations, ['object' => 'The :attribute object type is invalid.']);
   }
 
   /**

--- a/tests/InteractionTest.php
+++ b/tests/InteractionTest.php
@@ -45,6 +45,14 @@ class InteractionTest extends TestCase {
     $this->assertNull($outcome->result);
     $this->assertArraySubset(['inception' => ['The inception object type is invalid.']], $outcome->errors->toArray());
   }
+
+  public function testEmailDomainExample() {
+    $outcome = CheckEmail::run(['email' => 'invalid email']);
+
+    $this->assertFalse($outcome->valid);
+    $this->assertNull($outcome->result);
+    $this->assertArraySubset(['email' => ['The email must be a valid email address.']], $outcome->errors->toArray());
+  }
 }
 
 class ConvertMetersToMiles extends Interaction {
@@ -71,5 +79,29 @@ class ConvertMetersToMiles extends Interaction {
     }
 
     return $this->meters * 0.000621371;
+  }
+}
+
+class CheckEmail extends Interaction {
+  /**
+   * You can use validations method to return the array of validations
+   * instead of the property validations
+   *
+   * @return array
+   */
+  public function validations() {
+    return [
+      'email' => 'required|email',
+    ];
+  }
+
+  /**
+   * Execute the interaction
+   *
+   * @return void
+   */
+  public function execute() {
+    // do whatever you want with the email
+    return $this->email;
   }
 }


### PR DESCRIPTION
This method can be optionally used instead of the property `validations` for better use with custom rules. Example usage:

```php
class CreatePhoneInteraction extends Interaction
{
    public function validations()
    {
        return [
            'phone' => ['required', new MyPhoneRule('BR')],
        ];
    }
}
```